### PR TITLE
Fix bedrock 1.21.50 protocol input flags

### DIFF
--- a/data/bedrock/1.21.50/protocol.json
+++ b/data/bedrock/1.21.50/protocol.json
@@ -10615,7 +10615,7 @@
     "InputFlag": [
       "bitflags",
       {
-        "type": "varint64",
+        "type": "varint128",
         "big": true,
         "flags": [
           "ascend",

--- a/data/bedrock/latest/proto.yml
+++ b/data/bedrock/latest/proto.yml
@@ -3157,7 +3157,7 @@ packet_player_auth_input:
 
 #TODO: update to use the new `shift` option in bitflags
 InputFlag: [ "bitflags", {
-   "type": "varint64", "big": true,
+   "type": "varint128", "big": true,
    "flags": [
       "ascend",
       "descend",


### PR DESCRIPTION
1.21.50 `player_auth_input` packet's input flags can exceed 64 bits. Fixed by using new 128-bit varint support in protodef.